### PR TITLE
Add support for displaying cards in the Alexa app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-libby",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {
@@ -4096,6 +4096,9 @@
       "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "themoviedbclient": {
+      "version": "git+https://github.com/josephschmitt/TheMovieDBClient.git#2324661187bdf3f06ca2b299eaa567b93c4ad3aa"
     },
     "through": {
       "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -755,11 +755,6 @@
       "integrity": "sha1-YvM+Slm0hV8N5LuJcr8bhBuYttI=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
-    },
     "error-ex": {
       "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
@@ -2069,11 +2064,6 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "is-typedarray": {
       "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
@@ -2215,7 +2205,8 @@
     },
     "lodash": {
       "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash._baseassign": {
       "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
@@ -2378,11 +2369,6 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true
     },
-    "node-fetch": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
-    },
     "node-forge": {
       "version": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
       "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
@@ -2458,11 +2444,6 @@
           }
         }
       }
-    },
-    "node-tvdb": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/node-tvdb/-/node-tvdb-3.2.0.tgz",
-      "integrity": "sha1-qwPpa7Sq/jXVjUDhNee18S4jmqs="
     },
     "node-zip": {
       "version": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -755,6 +755,11 @@
       "integrity": "sha1-YvM+Slm0hV8N5LuJcr8bhBuYttI=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+    },
     "error-ex": {
       "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
@@ -2064,6 +2069,11 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
     "is-typedarray": {
       "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
@@ -2205,8 +2215,7 @@
     },
     "lodash": {
       "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
       "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
@@ -2369,6 +2378,11 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
+    },
     "node-forge": {
       "version": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
       "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
@@ -2444,6 +2458,11 @@
           }
         }
       }
+    },
+    "node-tvdb": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-tvdb/-/node-tvdb-3.2.0.tgz",
+      "integrity": "sha1-qwPpa7Sq/jXVjUDhNee18S4jmqs="
     },
     "node-zip": {
       "version": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "config": "^1.26.1",
     "couchpotato-api": "^0.1.0",
     "node-sickbeard": "0.0.1",
+    "node-tvdb": "^3.2.0",
     "sonarr-api": "^0.2.0",
     "themoviedbclient": "git+https://github.com/josephschmitt/TheMovieDBClient.git",
     "url": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "config": "^1.26.1",
     "couchpotato-api": "^0.1.0",
     "node-sickbeard": "0.0.1",
-    "node-tvdb": "^3.2.0",
     "sonarr-api": "^0.2.0",
     "themoviedbclient": "git+https://github.com/josephschmitt/TheMovieDBClient.git",
     "url": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-libby",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "description": "A skill to ask Alexa about your Movie and TV Show library queues.",
   "main": "dist/index.js",
   "scripts": {
@@ -28,6 +28,7 @@
     "couchpotato-api": "^0.1.0",
     "node-sickbeard": "0.0.1",
     "sonarr-api": "^0.2.0",
+    "themoviedbclient": "git+https://github.com/josephschmitt/TheMovieDBClient.git",
     "url": "^0.11.0"
   },
   "devDependencies": {

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -1,13 +1,15 @@
 import config from 'config';
 import url from 'url';
 
+import {PROVIDER_TYPE} from '~/api/getProvider.js';
+
 /**
  * Returns a config object for a given API provider.
  *
  * @param {String} providerType -- "movie" or "show"
  * @returns {Object}
  */
-export default function (providerType = 'movies') {
+export default function (providerType = PROVIDER_TYPE.MOVIES) {
   const baseConfig = config.get('alexa-libby');
   const serverConfig = baseConfig.server || {};
   const mediaConfig = baseConfig[providerType] || {};

--- a/src/api/couchpotato.js
+++ b/src/api/couchpotato.js
@@ -6,7 +6,7 @@ import serverConfig from '~/api/config.js';
  * @property {String} title
  * @property {Number} year
  * @property {String} tmdbId
- * @property {String} imdb
+ * @property {String} imdbId
  * @property {String} [status]
  * @property {String} [quality]
  */
@@ -49,7 +49,7 @@ export async function search(query) {
  * @returns {Object} -- Couch Potato response object
  */
 export async function add(movie) {
-  return await couchpotato().get('movie.add', {title: movie.title, identifier: movie.imdb});
+  return await couchpotato().get('movie.add', {title: movie.title, identifier: movie.imdbId});
 }
 
 function formatMovieResult(movie) {
@@ -57,7 +57,7 @@ function formatMovieResult(movie) {
     title: movie.title || movie.original_title || movie.titles[0],
     year: movie.year || movie.info.year,
     tmdbId: movie.tmdb_id || movie.info.tmdb_id,
-    imdb: movie.imdb || movie.info.imdb,
+    imdbId: movie.imdb || movie.info.imdb,
     status: movie.status || '',
     quality: movie.releases && movie.releases.length ? movie.releases[0].quality : null
   };

--- a/src/api/radarr.js
+++ b/src/api/radarr.js
@@ -7,6 +7,7 @@ import serverConfig from '~/api/config.js';
  * @property {String} slug
  * @property {Number} year
  * @property {String} tmdbId
+ * @property {String} imdbId
  * @property {Array} images
  * @property {String} [status]
  * @property {String} [quality]
@@ -93,6 +94,7 @@ function mapToMediaResult(movie) {
     slug: movie.titleSlug,
     year: movie.year,
     tmdbId: movie.tmdbId,
+    imdbId: movie.imdbId,
     images: movie.images,
     status: movie.status,
     quality: quality ? quality.name : ''

--- a/src/api/sickbeard.js
+++ b/src/api/sickbeard.js
@@ -5,7 +5,7 @@ import serverConfig from '~/api/config.js';
  * @typedef {Object} MediaResult
  * @property {String} title
  * @property {Number} [year]
- * @property {String} tvdbid
+ * @property {String} tvdbId
  * @property {String} [status]
  * @property {String} [quality]
  */
@@ -34,7 +34,7 @@ export async function list(title) {
     return {
       title: show.show_name,
       year: show.year,
-      tvdbid: show.tvdbid,
+      tvdbId: show.tvdbid,
       status: show.status.toLowerCase(),
       quality: show.quality
     };
@@ -63,7 +63,7 @@ export async function search(query) {
     return {
       title: show.name,
       year: new Date(show.first_aired).getFullYear(),
-      tvdbid: show.tvdbid
+      tvdbId: show.tvdbid
     };
   }) : [];
 }
@@ -75,5 +75,5 @@ export async function search(query) {
  * @returns {Object} -- Sickbeard response object
  */
 export async function add(show) {
-  return await sickbeard().cmd('show.addnew', {tvdbid: show.tvdbid, status: 'wanted'});
+  return await sickbeard().cmd('show.addnew', {tvdbid: show.tvdbId, status: 'wanted'});
 }

--- a/src/api/sonarr.js
+++ b/src/api/sonarr.js
@@ -7,6 +7,7 @@ import serverConfig from '~/api/config.js';
  * @property {String} slug
  * @property {Number} year
  * @property {String} tvdbId
+ * @property {String} imdbId
  * @property {Array} images
  * @property {String} [status]
  * @property {String} [quality]
@@ -90,6 +91,7 @@ function mapToMediaResult(show) {
     slug: show.titleSlug,
     year: show.year,
     tvdbId: show.tvdbId,
+    imdbId: show.imdbId,
     images: show.images,
     status: show.status,
     quality: quality ? quality.name : ''

--- a/src/handlers/general.js
+++ b/src/handlers/general.js
@@ -2,7 +2,7 @@ import getProvider, {PROVIDER_TYPE} from '~/api/getProvider.js';
 
 import buildCard from '~/lib/buildCard.js';
 import buildReprompt from '~/lib/buildReprompt.js';
-import getArtwork, {ARTWORK_SERVICE} from '~/lib/getArtwork.js';
+import getArtwork from '~/lib/getArtwork.js';
 
 import {
   CANCEL_RESPONSE,
@@ -38,8 +38,7 @@ export function handleYesIntent(req, resp) {
         return null;
       }
 
-      const id = promptData.providerType === PROVIDER_TYPE.MOVIES ? result.tmdbId : result.tvdbId;
-      return getArtwork(ARTWORK_SERVICE.TMDB, id);
+      return getArtwork(result);
     }).then((artwork) => {
       if (artwork) {
         let title = result.title;

--- a/src/handlers/movies.js
+++ b/src/handlers/movies.js
@@ -1,6 +1,8 @@
 import getProvider, {PROVIDER_TYPE} from '~/api/getProvider.js';
 
+import buildCard from '~/lib/buildCard.js';
 import buildReprompt from '~/lib/buildReprompt.js';
+import getArtwork, {ARTWORK_SERVICE} from '~/lib/getArtwork.js';
 import parseDate from '~/lib/parseDate.js';
 
 import {
@@ -28,6 +30,7 @@ export async function handleFindMovieIntent(req, resp) {
     movies = await api.search(query);
     if (movies && movies.length) {
       const [topResult] = movies;
+
       resp
         .say(ADD_PROMPT(topResult.title, topResult.year))
         .session('promptData', buildReprompt(movies, PROVIDER_TYPE.MOVIES))
@@ -38,7 +41,14 @@ export async function handleFindMovieIntent(req, resp) {
   }
 
   const [result] = movies;
-  return Promise.resolve(resp.say(ALREADY_WANTED(result.title, result.year)));
+  const responseText = ALREADY_WANTED(result.title, result.year);
+
+  const artwork = await getArtwork(ARTWORK_SERVICE.TMDB, result.tmdbId);
+  if (artwork) {
+    resp.card(buildCard(`${result.title} (${result.year})`, artwork, responseText));
+  }
+
+  return Promise.resolve(resp.say(responseText));
 }
 
 export async function handleAddMovieIntent(req, resp) {

--- a/src/handlers/movies.js
+++ b/src/handlers/movies.js
@@ -2,7 +2,7 @@ import getProvider, {PROVIDER_TYPE} from '~/api/getProvider.js';
 
 import buildCard from '~/lib/buildCard.js';
 import buildReprompt from '~/lib/buildReprompt.js';
-import getArtwork, {ARTWORK_SERVICE} from '~/lib/getArtwork.js';
+import getArtwork from '~/lib/getArtwork.js';
 import parseDate from '~/lib/parseDate.js';
 
 import {
@@ -43,7 +43,7 @@ export async function handleFindMovieIntent(req, resp) {
   const [result] = movies;
   const responseText = ALREADY_WANTED(result.title, result.year);
 
-  const artwork = await getArtwork(ARTWORK_SERVICE.TMDB, result.tmdbId);
+  const artwork = await getArtwork(result);
   if (artwork) {
     resp.card(buildCard(`${result.title} (${result.year})`, artwork, responseText));
   }

--- a/src/handlers/shows.js
+++ b/src/handlers/shows.js
@@ -1,6 +1,8 @@
 import getProvider, {PROVIDER_TYPE} from '~/api/getProvider.js';
 
+import buildCard from '~/lib/buildCard.js';
 import buildReprompt from '~/lib/buildReprompt.js';
+import getArtwork, {ARTWORK_SERVICE} from '~/lib/getArtwork.js';
 
 import {
   ADD_SHOW,
@@ -30,9 +32,14 @@ export async function handleFindShowIntent(req, resp) {
       .shouldEndSession(false);
   }
   else {
-    resp
-      .say(ALREADY_WANTED(result.title.replace('\'s', 's')))
-      .send();
+    const responseText = ALREADY_WANTED(result.title.replace('\'s', 's'));
+
+    const artwork = await getArtwork(ARTWORK_SERVICE.TVDB, result.tvdbId);
+    if (artwork) {
+      resp.card(buildCard(result.title, artwork, responseText));
+    }
+
+    return resp.say(responseText);
   }
 }
 

--- a/src/handlers/shows.js
+++ b/src/handlers/shows.js
@@ -2,7 +2,7 @@ import getProvider, {PROVIDER_TYPE} from '~/api/getProvider.js';
 
 import buildCard from '~/lib/buildCard.js';
 import buildReprompt from '~/lib/buildReprompt.js';
-import getArtwork, {ARTWORK_SERVICE} from '~/lib/getArtwork.js';
+import getArtwork from '~/lib/getArtwork.js';
 
 import {
   ADD_SHOW,
@@ -34,7 +34,7 @@ export async function handleFindShowIntent(req, resp) {
   else {
     const responseText = ALREADY_WANTED(result.title.replace('\'s', 's'));
 
-    const artwork = await getArtwork(ARTWORK_SERVICE.TVDB, result.tvdbId);
+    const artwork = await getArtwork(result);
     if (artwork) {
       resp.card(buildCard(result.title, artwork, responseText));
     }

--- a/src/lib/buildCard.js
+++ b/src/lib/buildCard.js
@@ -1,0 +1,8 @@
+export default function buildCard(title, image, text) {
+  return {
+    type: 'Standard',
+    title,
+    text,
+    image
+  };
+}

--- a/src/lib/getArtwork.js
+++ b/src/lib/getArtwork.js
@@ -1,5 +1,6 @@
-import TMDBClient from 'themoviedbclient';
 import config from 'config';
+import TVDBClient from 'node-tvdb';
+import TMDBClient from 'themoviedbclient';
 
 import {PROVIDER_TYPE} from '~/api/getProvider.js';
 
@@ -27,7 +28,7 @@ export default async function getArtwork(serviceName, mediaId) {
     return await getTmdbArtwork(mediaId);
   }
   else if (serviceName === ARTWORK_SERVICE.TVDB) {
-    return null;
+    return await getTvdbArtwork(mediaId);
   }
 
   throw new Error('Unsupported artwork service: ' + serviceName);
@@ -50,6 +51,23 @@ async function getTmdbArtwork(mediaId) {
     return {
       smallImageUrl: tmdb.getImageUrl(movie.poster_path, 'w780'),
       largeImageUrl: tmdb.getImageUrl(movie.poster_path, 'w1280')
+    };
+  }
+  catch (e) {
+    return null;
+  }
+}
+
+async function getTvdbArtwork(mediaId) {
+  try {
+    const apiKey = config.get(`alexa-libby.${PROVIDER_TYPE.SHOWS}.tvdb.apiKey`);
+    const tvdb = new TVDBClient(apiKey);
+
+    const [poster] = await tvdb.getSeriesPosters(mediaId);
+
+    return {
+      smallImageUrl: `https://thetvdb.com/banners/${poster.fileName}`,
+      largeImageUrl: `https://thetvdb.com/banners/${poster.fileName}`
     };
   }
   catch (e) {

--- a/src/lib/getArtwork.js
+++ b/src/lib/getArtwork.js
@@ -1,0 +1,58 @@
+import TMDBClient from 'themoviedbclient';
+import config from 'config';
+
+import {PROVIDER_TYPE} from '~/api/getProvider.js';
+
+export const ARTWORK_SERVICE = {
+  TMDB: 'tmdb',
+  TVDB: 'tvdb'
+};
+
+/**
+ * @typedef ArtworkImages
+ * @property {String} smallImageUrl
+ * @property {String} largeImageUrl
+ */
+
+/**
+ * Queries various artwork API services and returns a large and small image url for use in a skill
+ * card.
+ *
+ * @param {String} serviceName -- ARTWORK_SERVICE.TMDB or ARTWORK_SERVICE.TVDB
+ * @param {String|Number} mediaId -- Unique id for the service. E.g. tvdbId or tmdbId
+ * @returns {PromiseLike<ArtworkImages>}
+ */
+export default async function getArtwork(serviceName, mediaId) {
+  if (serviceName === ARTWORK_SERVICE.TMDB) {
+    return await getTmdbArtwork(mediaId);
+  }
+  else if (serviceName === ARTWORK_SERVICE.TVDB) {
+    return null;
+  }
+
+  throw new Error('Unsupported artwork service: ' + serviceName);
+}
+
+async function getTmdbArtwork(mediaId) {
+  try {
+    const apiKey = config.get(`alexa-libby.${PROVIDER_TYPE.MOVIES}.tmdb.apiKey`);
+    const tmdb = new TMDBClient(apiKey);
+
+    tmdb.configure({
+      ssl: true
+    });
+
+    const movie = await tmdb.call(`/movie/${mediaId}`);
+    if (!movie) {
+      return null;
+    }
+
+    return {
+      smallImageUrl: tmdb.getImageUrl(movie.poster_path, 'w780'),
+      largeImageUrl: tmdb.getImageUrl(movie.poster_path, 'w1280')
+    };
+  }
+  catch (e) {
+    return null;
+  }
+}

--- a/src/lib/getArtwork.js
+++ b/src/lib/getArtwork.js
@@ -1,5 +1,5 @@
 import config from 'config';
-import TMDBClient from 'themoviedbclient';
+import themoviedbclient from 'themoviedbclient';
 
 /**
  * @typedef {Object} ArtworkOptions
@@ -13,6 +13,11 @@ import TMDBClient from 'themoviedbclient';
  * @property {String} smallImageUrl
  * @property {String} largeImageUrl
  */
+
+/* Dumb workaround to make this easier to stub and test */
+export const API = {
+  Client: themoviedbclient
+};
 
 /**
  * Fetches TMDB for artwork for a MediaResult and returns a large and small image url for use in a
@@ -29,7 +34,7 @@ export default async function getArtwork({tmdbId, tvdbId, imdbId}) {
 
   try {
     const apiKey = config.get('alexa-libby.artwork.tmdbApiKey');
-    const tmdb = new TMDBClient(apiKey);
+    const tmdb = new API.Client(apiKey);
     tmdb.configure({ssl: true});
 
     let media;
@@ -37,8 +42,8 @@ export default async function getArtwork({tmdbId, tvdbId, imdbId}) {
       media = await tmdb.call(`/movie/${tmdbId}`);
     }
     else {
-      const results = await tmdb.call(`/find/${tmdbId || imdbId}`, {
-        external_source: tmdbId ? 'tvdb_id' : 'imdb_id'
+      const results = await tmdb.call(`/find/${tvdbId || imdbId}`, {
+        external_source: tvdbId ? 'tvdb_id' : 'imdb_id'
       });
       media = results.tv_results.length ? results.tv_results[0] : results.movie_results[0];
     }

--- a/test/api/couchpotato.js
+++ b/test/api/couchpotato.js
@@ -486,7 +486,7 @@ describe('api.couchpotato', () => {
     it('should format the movie response to use standardized keys', async () => {
       const movies = await couchpotato.list();
       assert.deepEqual(Object.keys(movies[0]),
-          ['title', 'year', 'tmdbId', 'imdb', 'status', 'quality']);
+          ['title', 'year', 'tmdbId', 'imdbId', 'status', 'quality']);
     });
 
     it('should fill in the correct data in the correct fields', async () => {
@@ -496,7 +496,7 @@ describe('api.couchpotato', () => {
         title: '10 Cloverfield Lane',
         year: 2016,
         tmdbId: 333371,
-        imdb: 'tt1179933',
+        imdbId: 'tt1179933',
         status: 'done',
         quality: '1080p'
       });
@@ -519,7 +519,7 @@ describe('api.couchpotato', () => {
         title: '10 Things I Hate About You',
         year: 1999,
         tmdbId: 4951,
-        imdb: 'tt0147800',
+        imdbId: 'tt0147800',
         status: 'done',
         quality: 'brrip'
       });
@@ -534,12 +534,12 @@ describe('api.couchpotato', () => {
         title: '12 Angry Men',
         year: 1957,
         tmdbId: 389,
-        imdb: 'tt0050083',
+        imdbId: 'tt0050083',
         status: 'done',
         quality: 'dvdr'
       };
 
-      cpApiStub.withArgs('movie.add', {title: movie.title, identifier: movie.imdb})
+      cpApiStub.withArgs('movie.add', {title: movie.title, identifier: movie.imdbId})
           .resolves(sampleAddMovieResponse);
     });
 

--- a/test/api/sickbeard.js
+++ b/test/api/sickbeard.js
@@ -140,7 +140,7 @@ describe('api.sickbeard', () => {
 
     it('should format the show response to use standardized keys', async () => {
       const shows = await sickbeard.list();
-      assert.deepEqual(Object.keys(shows[0]), ['title', 'year', 'tvdbid', 'status', 'quality']);
+      assert.deepEqual(Object.keys(shows[0]), ['title', 'year', 'tvdbId', 'status', 'quality']);
     });
 
     it('should fill in the correct data in the correct fields', async () => {
@@ -149,7 +149,7 @@ describe('api.sickbeard', () => {
       assert.deepEqual(show, {
         title: 'Law & Order: Criminal Intent',
         year: undefined,
-        tvdbid: 71489,
+        tvdbId: 71489,
         status: 'ended',
         quality: 'HD720p'
       });
@@ -170,11 +170,11 @@ describe('api.sickbeard', () => {
 
       assert.deepEqual(shows, [{
         title: 'The Tonight Show with Jay Leno',
-        tvdbid: 70336,
+        tvdbId: 70336,
         year: '1992'
       }, {
         title: 'The Jay Leno Show',
-        tvdbid: 113921,
+        tvdbId: 113921,
         year: '2009'
       }]);
     });
@@ -186,7 +186,7 @@ describe('api.sickbeard', () => {
     beforeEach(() => {
       show = {
         title: 'Conan (2010)',
-        tvdbid: 194751,
+        tvdbId: 194751,
         year: '2011'
       };
 

--- a/test/handlers/movies.js
+++ b/test/handlers/movies.js
@@ -39,7 +39,8 @@ const sampleSession = {
 const sampleMovie = {
   title: 'My Movie',
   year: 2000,
-  tvdbid: 12345,
+  tmdbId: 12345,
+  imdbId: 12345,
   status: 'in library',
   quality: '1080p'
 };
@@ -47,7 +48,8 @@ const sampleMovie = {
 const sampleMovieResult = {
   title: 'My Search Movie',
   year: 2010,
-  tvdbid: 123456,
+  tmdbId: 123456,
+  imdbId: 123456,
   status: 'wanted',
   quality: '1080p'
 };

--- a/test/lib/getArtwork.js
+++ b/test/lib/getArtwork.js
@@ -1,0 +1,110 @@
+import assert from 'assert';
+import config from 'config';
+import sinon from 'sinon';
+
+import getArtwork, {API} from '~/lib/getArtwork.js';
+
+describe('lib.getArtwork', () => {
+  let apiStubs, configStub, sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    configStub = sandbox.stub(config, 'get').withArgs('alexa-libby.artwork.tmdbApiKey')
+        .returns('1234');
+
+    apiStubs = {
+      call: sandbox.stub(),
+      configure: sandbox.stub(),
+      getImageUrl: sandbox.stub().callsFake((filename, size) => `${size}/${filename}`)
+    };
+
+    sandbox.stub(API, 'Client').callsFake((apiKey) => {
+      if (apiKey) {
+        return apiStubs;
+      }
+      else {
+        throw new Error();
+      }
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should throw an error if it cannot get a valid media id', async () => {
+    try {
+      await getArtwork({});
+    }
+    catch (e) {
+      assert.equal(e.message,
+          'You must provide a valid tmdbId, tvdbId, or imdbId to fetch artwork');
+    }
+  });
+
+  it('should return null if there is no configured TMDB api key', async () => {
+    configStub.returns(null);
+
+    assert.equal(await getArtwork({tmdbId: 1234}), null);
+  });
+
+  it('should return null if no media is found', async () => {
+    apiStubs.call.withArgs('/movie/1234').returns(undefined);
+
+    assert.equal(await getArtwork({tmdbId: 1234}), null);
+  });
+
+  it('should call the TMDB API when it has a tmdbId', async () => {
+    apiStubs.call.withArgs('/movie/1234').resolves({
+      poster_path: 'myPoster.jpg'
+    });
+
+    assert.deepEqual(await getArtwork({tmdbId: 1234}), {
+      smallImageUrl: 'w780/myPoster.jpg',
+      largeImageUrl: 'w1280/myPoster.jpg'
+    });
+  });
+
+  it('should call the TMDB find API when it has a tvdbId', async () => {
+    apiStubs.call.withArgs('/find/1234', {external_source: 'tvdb_id'}).resolves({
+      movie_results: [],
+      tv_results: [{
+        poster_path: 'myPoster.jpg'
+      }]
+    });
+
+    assert.deepEqual(await getArtwork({tvdbId: 1234}), {
+      smallImageUrl: 'w780/myPoster.jpg',
+      largeImageUrl: 'w1280/myPoster.jpg'
+    });
+  });
+
+  it('should call the TMDB find API when it has an imdbId movie', async () => {
+    apiStubs.call.withArgs('/find/1234', {external_source: 'imdb_id'}).resolves({
+      movie_results: [{
+        poster_path: 'myPoster.jpg'
+      }],
+      tv_results: []
+    });
+
+    assert.deepEqual(await getArtwork({imdbId: 1234}), {
+      smallImageUrl: 'w780/myPoster.jpg',
+      largeImageUrl: 'w1280/myPoster.jpg'
+    });
+  });
+
+  it('should call the TMDB find API when it has an imdbId TV show', async () => {
+    apiStubs.call.withArgs('/find/1234', {external_source: 'imdb_id'}).resolves({
+      movie_results: [],
+      tv_results: [{
+        poster_path: 'myPoster.jpg'
+      }]
+    });
+
+    assert.deepEqual(await getArtwork({imdbId: 1234}), {
+      smallImageUrl: 'w780/myPoster.jpg',
+      largeImageUrl: 'w1280/myPoster.jpg'
+    });
+  });
+});


### PR DESCRIPTION
This requires providing an API key for TMDB, which is where we get the artwork from. You can do so in the config in the new `artwork` section:

```
  "server": {...},
  "movies": {...},
  "shows": {...},
  "artwork": {
    "tmdbApiKey": "abcdefghijklmnopqrstuvwxyz123456"
  }
```

Once configured correctly, a card will be displayed for Movies and Shows in the Alexa app (or in the Echo Show if you have one) after checking if a movie or show is already on your list, or after adding a new movie or show.

![](http://drp.joe.sh/5vCt39YbiBjE4gQJjoHo/Photo-2017-07-01-13-53.jpg)