### PR TITLE
Add new config option for choosing a quality when adding media in sonarr/radarr

### DIFF
--- a/src/api/radarr.js
+++ b/src/api/radarr.js
@@ -68,7 +68,7 @@ export async function search(query) {
  */
 export async function add(movie) {
   const [rootFolderResp] = await radarr().get('rootfolder');
-  const preferredQuality = config.get(`alexa-libby.${PROVIDER_TYPE.MOVIES}.quality`);
+  const preferredQuality = getPreferredQuality();
   const qualities = await loadQualityProfiles();
   const quality = qualities.find((qt) => {
     return qt.name === preferredQuality;
@@ -96,7 +96,7 @@ async function loadQualityProfiles() {
 }
 
 function mapToMediaResult(movie) {
-  const preferredQuality = config.get(`alexa-libby.${PROVIDER_TYPE.MOVIES}.quality`);
+  const preferredQuality = getPreferredQuality();
   const quality = _qualityProfiles.find((profile) => {
     return profile.id === movie.qualityProfileId || profile.name === preferredQuality;
   });
@@ -111,4 +111,14 @@ function mapToMediaResult(movie) {
     status: movie.status,
     quality: quality ? quality.name : 'Any'
   };
+}
+
+function getPreferredQuality() {
+  const path = `alexa-libby.${PROVIDER_TYPE.MOVIES}.quality`;
+
+  if (config.has(path)) {
+    return config.get(path);
+  }
+
+  return null;
 }

--- a/src/api/radarr.js
+++ b/src/api/radarr.js
@@ -68,10 +68,10 @@ export async function search(query) {
  */
 export async function add(movie) {
   const [rootFolderResp] = await radarr().get('rootfolder');
-  const preferredQuality = config(`alexa-libby.${PROVIDER_TYPE.MOVIES}.quality`);
+  const preferredQuality = config.get(`alexa-libby.${PROVIDER_TYPE.MOVIES}.quality`);
   const qualities = await loadQualityProfiles();
   const quality = qualities.find((qt) => {
-    qt.name === preferredQuality;
+    return qt.name === preferredQuality;
   });
 
   return await radarr().post('movie', {
@@ -79,7 +79,7 @@ export async function add(movie) {
     title: movie.title,
     titleSlug: movie.slug,
     images: movie.images,
-    qualityProfileId: quality.id || 1, // Default to 'Any' if no profile set in config
+    qualityProfileId: quality ? quality.id : 1, // Default to 'Any' if no profile set in config
     rootFolderPath: rootFolderResp.path,
     addOptions: {
       searchForMovie: true
@@ -96,9 +96,9 @@ async function loadQualityProfiles() {
 }
 
 function mapToMediaResult(movie) {
-  const preferredQuality = config(`alexa-libby.${PROVIDER_TYPE.MOVIES}.quality`);
+  const preferredQuality = config.get(`alexa-libby.${PROVIDER_TYPE.MOVIES}.quality`);
   const quality = _qualityProfiles.find((profile) => {
-    profile.id === movie.qualityProfileId || profile.name === preferredQuality;
+    return profile.id === movie.qualityProfileId || profile.name === preferredQuality;
   });
 
   return {

--- a/src/api/sonarr.js
+++ b/src/api/sonarr.js
@@ -20,7 +20,7 @@ let _sonarr, _qualityProfiles;
 
 export default function sonarr() {
   if (!_sonarr) {
-    _sonarr = new SonarrAPI(serverConfig('shows'));
+    _sonarr = new SonarrAPI(serverConfig(PROVIDER_TYPE.SHOWS));
   }
 
   return _sonarr;
@@ -68,7 +68,7 @@ export async function search(query) {
  */
 export async function add(show) {
   const [rootFolderResp] = await sonarr().get('rootfolder');
-  const preferredQuality = config.get(`alexa-libby.${PROVIDER_TYPE.SHOWS}.quality`);
+  const preferredQuality = getPreferredQuality();
   const qualities = await loadQualityProfiles();
   const quality = qualities.find((qt) => {
     return qt.name === preferredQuality;
@@ -93,7 +93,7 @@ async function loadQualityProfiles() {
 }
 
 function mapToMediaResult(show) {
-  const preferredQuality = config.get(`alexa-libby.${PROVIDER_TYPE.SHOWS}.quality`);
+  const preferredQuality = getPreferredQuality();
   const quality = _qualityProfiles.find((profile) => {
     return profile.id === show.qualityProfileId || profile.name === preferredQuality;
   });
@@ -108,4 +108,14 @@ function mapToMediaResult(show) {
     status: show.status,
     quality: quality ? quality.name : ''
   };
+}
+
+function getPreferredQuality() {
+  const path = `alexa-libby.${PROVIDER_TYPE.SHOWS}.quality`;
+
+  if (config.has(path)) {
+    return config.get(path);
+  }
+
+  return null;
 }

--- a/src/api/sonarr.js
+++ b/src/api/sonarr.js
@@ -68,10 +68,10 @@ export async function search(query) {
  */
 export async function add(show) {
   const [rootFolderResp] = await sonarr().get('rootfolder');
-  const preferredQuality = config(`alexa-libby.${PROVIDER_TYPE.SHOWS}.quality`);
+  const preferredQuality = config.get(`alexa-libby.${PROVIDER_TYPE.SHOWS}.quality`);
   const qualities = await loadQualityProfiles();
   const quality = qualities.find((qt) => {
-    qt.name === preferredQuality;
+    return qt.name === preferredQuality;
   });
 
   return await sonarr().post('series', {
@@ -79,7 +79,7 @@ export async function add(show) {
     title: show.title,
     titleSlug: show.slug,
     images: show.images,
-    qualityProfileId: quality.id || 1,
+    qualityProfileId: quality ? quality.id : 1, // Default to 'Any' if no profile set in config
     rootFolderPath: rootFolderResp.path
   });
 }
@@ -93,9 +93,9 @@ async function loadQualityProfiles() {
 }
 
 function mapToMediaResult(show) {
-  const preferredQuality = config(`alexa-libby.${PROVIDER_TYPE.SHOWS}.quality`);
+  const preferredQuality = config.get(`alexa-libby.${PROVIDER_TYPE.SHOWS}.quality`);
   const quality = _qualityProfiles.find((profile) => {
-    profile.id === show.qualityProfileId || profile.name === preferredQuality;
+    return profile.id === show.qualityProfileId || profile.name === preferredQuality;
   });
 
   return {

--- a/test/api/couchpotato.js
+++ b/test/api/couchpotato.js
@@ -469,10 +469,6 @@ describe('api.couchpotato', () => {
       });
     });
 
-    afterEach(() => {
-      sandbox.reset();
-    });
-
     it('should list all the movies', async () => {
       const movies = await couchpotato.list();
       assert.equal(movies.length, 3);
@@ -508,10 +504,6 @@ describe('api.couchpotato', () => {
       cpApiStub.withArgs('movie.search', {q: '10'}).resolves(sampleMoviesResponse);
     });
 
-    afterEach(() => {
-      sandbox.reset();
-    });
-
     it('should return a formatted result', async () => {
       const movies = await couchpotato.search('10');
 
@@ -541,10 +533,6 @@ describe('api.couchpotato', () => {
 
       cpApiStub.withArgs('movie.add', {title: movie.title, identifier: movie.imdbId})
           .resolves(sampleAddMovieResponse);
-    });
-
-    afterEach(() => {
-      sandbox.reset();
     });
 
     it('should return a correct response', async () => {

--- a/test/api/couchpotato.js
+++ b/test/api/couchpotato.js
@@ -447,12 +447,13 @@ describe('api.couchpotato', () => {
   let cpApiStub, sandbox;
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    cpApiStub = sandbox.stub(couchpotato.default(), 'get');
 
     sandbox.stub(serverConfig, 'default').returns({
       hostname: 'http://localhost',
       apiKey: 'abcdefghijklmnopqrstuvwxyz123456'
     });
+
+    cpApiStub = sandbox.stub(couchpotato.default(), 'get');
   });
 
   afterEach(() => {

--- a/test/api/radarr.js
+++ b/test/api/radarr.js
@@ -258,6 +258,12 @@ describe('api.radarr', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+
+    sandbox.stub(serverConfig, 'default').returns({
+      hostname: 'http://localhost',
+      apiKey: 'abcdefghijklmnopqrstuvwxyz123456'
+    });
+
     apiStub = sandbox.stub(radarr.default(), 'get');
 
     apiStub.withArgs('rootfolder').resolves([{path: ''}]);
@@ -265,11 +271,6 @@ describe('api.radarr', () => {
       {id: 1, name: 'Any'},
       {id: 2, name: 'HDTV-1080p'}
     ]);
-
-    sandbox.stub(serverConfig, 'default').returns({
-      hostname: 'http://localhost',
-      apiKey: 'abcdefghijklmnopqrstuvwxyz123456'
-    });
   });
 
   afterEach(() => {
@@ -413,7 +414,9 @@ describe('api.radarr', () => {
     });
 
     it('should add using the quality from the config', async () => {
+      sandbox.stub(config, 'has').withArgs('alexa-libby.movies.quality').returns(true);
       sandbox.stub(config, 'get').withArgs('alexa-libby.movies.quality').returns('HDTV-1080p');
+
       const argWithQuality = merge(addArg, {qualityProfileId: 2});
 
       await radarr.add(movie);

--- a/test/api/radarr.js
+++ b/test/api/radarr.js
@@ -1,0 +1,423 @@
+import assert from 'assert';
+import config from 'config';
+import merge from 'deepmerge';
+import sinon from 'sinon';
+
+import * as serverConfig from '~/api/config.js';
+import * as radarr from '~/api/radarr.js';
+
+/* eslint-disable max-len */
+const sampleMoviesResponse = [
+  {
+    title: '10 Cloverfield Lane',
+    sortTitle: '10 cloverfield lane',
+    sizeOnDisk: 7847269480,
+    status: 'released',
+    overview: 'After a car accident, Michelle awakens to find herself in a mysterious bunker with two men named Howard and Emmett. Howard offers her a pair of crutches to help her remain mobile with her leg injury sustained from the car crash and tells her to "get good on those" before leaving the bunker. She has been given the information that there has been an alien attack and the outside world is poisoned. However, Howard and Emmett\'s intentions soon become questionable and Michelle is faced with a question: Is it better in here or out there?',
+    inCinemas: '2016-03-10T05:00:00Z',
+    physicalRelease: '2016-07-25T00:00:00Z',
+    images: [
+      {
+        coverType: 'poster',
+        url: '/movies/MediaCover/1/poster.jpg?lastWrite=636322052260000000'
+      },
+      {
+        coverType: 'banner',
+        url: '/movies/MediaCover/1/banner.jpg?lastWrite=636322052300000000'
+      }
+    ],
+    website: 'http://www.10cloverfieldlane.com/',
+    downloaded: true,
+    year: 2016,
+    hasFile: true,
+    youTubeTrailerId: 'saHzng8fxLs',
+    studio: 'Paramount Pictures',
+    path: '/Library/Movies/10 Cloverfield Lane (2016)',
+    profileId: 1,
+    pathState: 'static',
+    monitored: false,
+    minimumAvailability: 'tba',
+    isAvailable: true,
+    folderName: '10 Cloverfield Lane (2016)',
+    runtime: 103,
+    lastInfoSync: '2017-07-02T00:47:58.498155Z',
+    cleanTitle: '10cloverfieldlane',
+    imdbId: 'tt1179933',
+    tmdbId: 333371,
+    titleSlug: '10-cloverfield-lane-333371',
+    genres: [
+      'Science Fiction'
+    ],
+    tags: [],
+    added: '2017-05-22T19:06:40.690805Z',
+    ratings: {
+      votes: 2149,
+      value: 6.8
+    },
+    alternativeTitles: [
+      '10 Cloverfield Lane',
+      'The Cellar',
+      'Untitled Bad Robot Project',
+      'Ten Cloverfield Lane',
+      'Valencia'
+    ],
+    movieFile: {
+      movieId: 0,
+      relativePath: '10 Cloverfield Lane (2016) - HD 1080p.m4v',
+      size: 7847269480,
+      dateAdded: '2017-05-22T19:06:54.288692Z',
+      quality: {
+        quality: {
+          id: 9,
+          name: 'HDTV-1080p'
+        },
+        revision: {
+          version: 1,
+          real: 0
+        }
+      },
+      mediaInfo: {
+        videoCodec: 'AVC',
+        videoBitrate: 9290408,
+        videoBitDepth: 8,
+        width: 1920,
+        height: 800,
+        audioFormat: 'AAC',
+        audioBitrate: 164187,
+        runTime: '01:43:34.7600000',
+        audioStreamCount: 2,
+        audioChannels: 2,
+        audioChannelPositions: '2/0/0',
+        audioChannelPositionsText: 'Front: L R',
+        audioProfile: 'LC',
+        videoFps: 23.976,
+        audioLanguages: 'English / English',
+        subtitles: 'Dutch',
+        scanType: 'Progressive',
+        schemaRevision: 3
+      },
+      id: 3
+    },
+    qualityProfileId: 1,
+    id: 1
+  },
+  {
+    title: 'Assassin\'s Creed',
+    sortTitle: 'assassins creed',
+    sizeOnDisk: 0,
+    status: 'released',
+    overview: 'Lynch discovers he is a descendant of the secret Assassins society through unlocked genetic memories that allow him to relive the adventures of his ancestor, Aguilar, in 15th Century Spain. After gaining incredible knowledge and skills he’s poised to take on the oppressive Knights Templar in the present day.',
+    inCinemas: '2016-12-21T00:00:00Z',
+    images: [
+      {
+        coverType: 'poster',
+        url: '/radarr/MediaCover/1/poster.jpg?lastWrite=636200219330000000'
+      },
+      {
+        coverType: 'banner',
+        url: '/radarr/MediaCover/1/banner.jpg?lastWrite=636200219340000000'
+      }
+    ],
+    website: 'https://www.ubisoft.com/en-US/',
+    downloaded: false,
+    year: 2016,
+    hasFile: false,
+    youTubeTrailerId: 'pgALJgMjXN4',
+    studio: '20th Century Fox',
+    path: '/Library/Movies/Assassin\'s Creed (2016)',
+    profileId: 2,
+    monitored: true,
+    minimumAvailability: 'preDB',
+    runtime: 115,
+    lastInfoSync: '2017-01-23T22:05:32.365337Z',
+    cleanTitle: 'assassinscreed',
+    imdbId: 'tt2094766',
+    tmdbId: 121856,
+    titleSlug: 'assassins-creed-121856',
+    genres: [
+      'Action',
+      'Adventure',
+      'Fantasy',
+      'Science Fiction'
+    ],
+    tags: [],
+    added: '2017-01-14T20:18:52.938244Z',
+    ratings: {
+      votes: 711,
+      value: 5.2
+    },
+    alternativeTitles: [
+      'Assassin\'s Creed: The IMAX Experience'
+    ],
+    qualityProfileId: 2,
+    id: 1
+  },
+  {
+    title: 'First Blood',
+    sortTitle: 'first blood',
+    sizeOnDisk: 3242061910,
+    status: 'released',
+    overview: 'When former Green Beret John Rambo is harassed by local law enforcement and arrested for vagrancy, the Vietnam vet snaps, runs for the hills and rat-a-tat-tats his way into the action-movie hall of fame. Hounded by a relentless sheriff, Rambo employs heavy-handed guerilla tactics to shake the cops off his tail.',
+    inCinemas: '1982-10-22T04:00:00Z',
+    physicalRelease: '2002-06-11T00:00:00Z',
+    images: [
+      {
+        coverType: 'poster',
+        url: '/movies/MediaCover/237/poster.jpg?lastWrite=636310780120000000'
+      },
+      {
+        coverType: 'banner',
+        url: '/movies/MediaCover/237/banner.jpg?lastWrite=636310780180000000'
+      }
+    ],
+    website: '',
+    downloaded: true,
+    year: 1982,
+    hasFile: true,
+    youTubeTrailerId: 'QzTmQwlUpV8',
+    studio: 'Orion Pictures',
+    path: '/Library/Movies/First Blood (1982)',
+    profileId: 1,
+    pathState: 'static',
+    monitored: false,
+    minimumAvailability: 'tba',
+    isAvailable: true,
+    folderName: 'First Blood (1982)',
+    runtime: 93,
+    lastInfoSync: '2017-07-02T00:49:36.179101Z',
+    cleanTitle: 'firstblood',
+    imdbId: 'tt0083944',
+    tmdbId: 1368,
+    titleSlug: 'first-blood-1368',
+    genres: [
+      'Action',
+      'Adventure',
+      'Thriller',
+      'War'
+    ],
+    tags: [],
+    added: '2017-05-22T19:26:22.525138Z',
+    ratings: {
+      votes: 1315,
+      value: 7.2
+    },
+    alternativeTitles: [
+      'First Blood',
+      'Rambo 1 - First Blood',
+      'Rambo',
+      'Rambo I',
+      'Rambo - First Blood Part I',
+      'Rambo I - First Blood',
+      'Rambo: First Blood'
+    ],
+    movieFile: {
+      movieId: 0,
+      relativePath: 'First Blood (1982) - HD 720p.mp4',
+      size: 3242061910,
+      dateAdded: '2017-05-22T19:32:50.919508Z',
+      quality: {
+        quality: {
+          id: 4,
+          name: 'HDTV-720p'
+        },
+        revision: {
+          version: 1,
+          real: 0
+        }
+      },
+      mediaInfo: {
+        videoCodec: 'AVC',
+        videoBitrate: 4499501,
+        videoBitDepth: 8,
+        width: 1280,
+        height: 544,
+        audioFormat: 'AAC',
+        audioBitrate: 127974,
+        runTime: '01:33:08.7500000',
+        audioStreamCount: 1,
+        audioChannels: 2,
+        audioChannelPositions: '2/0/0',
+        audioChannelPositionsText: 'Front: L R',
+        audioProfile: 'LC',
+        videoFps: 23.976,
+        audioLanguages: '',
+        subtitles: '',
+        scanType: 'Progressive',
+        schemaRevision: 3
+      },
+      id: 233
+    },
+    qualityProfileId: 1,
+    id: 237
+  }
+];
+/* eslint-enable max-len */
+
+describe('api.radarr', () => {
+  let apiStub, sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    apiStub = sandbox.stub(radarr.default(), 'get');
+
+    apiStub.withArgs('rootfolder').resolves([{path: ''}]);
+    apiStub.withArgs('profile').resolves([
+      {id: 1, name: 'Any'},
+      {id: 2, name: 'HDTV-1080p'}
+    ]);
+
+    sandbox.stub(serverConfig, 'default').returns({
+      hostname: 'http://localhost',
+      apiKey: 'abcdefghijklmnopqrstuvwxyz123456'
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('.list()', () => {
+    beforeEach(() => {
+      apiStub.withArgs('movie').resolves(sampleMoviesResponse);
+      apiStub.withArgs('movie', {search: 'First Blood'}).resolves([
+        sampleMoviesResponse[2]
+      ]);
+    });
+
+    it('should list all the movies', async () => {
+      const movies = await radarr.list();
+      assert.equal(movies.length, 3);
+    });
+
+    it('should list just movies with matching titles', async () => {
+      const movies = await radarr.list('First Blood');
+      assert.equal(movies.length, 1);
+    });
+
+    it('should format the movie response to use standardized keys', async () => {
+      const movies = await radarr.list();
+      assert.deepEqual(Object.keys(movies[0]),
+          ['title', 'slug', 'year', 'tmdbId', 'imdbId', 'images', 'status', 'quality']);
+    });
+
+    it('should fill in the correct data in the correct fields', async () => {
+      const [movie] = await radarr.list();
+
+      assert.deepEqual(movie, {
+        title: '10 Cloverfield Lane',
+        slug: '10-cloverfield-lane-333371',
+        year: 2016,
+        tmdbId: 333371,
+        imdbId: 'tt1179933',
+        images: [
+          {
+            coverType: 'poster',
+            url: '/movies/MediaCover/1/poster.jpg?lastWrite=636322052260000000'
+          },
+          {
+            coverType: 'banner',
+            url: '/movies/MediaCover/1/banner.jpg?lastWrite=636322052300000000'
+          }
+        ],
+        status: 'released',
+        quality: 'Any'
+      });
+    });
+  });
+
+  describe('.search()', () => {
+    beforeEach(() => {
+      apiStub.withArgs('movies/lookup', {term: 'assassin'}).resolves([
+        sampleMoviesResponse[1]
+      ]);
+    });
+
+    it('should return a formatted result', async () => {
+      const [topResult] = await radarr.search('assassin');
+
+      assert.deepEqual(topResult, {
+        title: 'Assassin\'s Creed',
+        slug: 'assassins-creed-121856',
+        year: 2016,
+        tmdbId: 121856,
+        imdbId: 'tt2094766',
+        images: [
+          {
+            coverType: 'poster',
+            url: '/radarr/MediaCover/1/poster.jpg?lastWrite=636200219330000000'
+          },
+          {
+            coverType: 'banner',
+            url: '/radarr/MediaCover/1/banner.jpg?lastWrite=636200219340000000'
+          }
+        ],
+        status: 'released',
+        quality: 'HDTV-1080p'
+      });
+    });
+  });
+
+  describe('.add()', () => {
+    let movie, addArg, postStub;
+
+    beforeEach(() => {
+      movie = {
+        title: 'First Blood',
+        slug: 'first-blood-1368',
+        year: 1982,
+        tmdbId: 1368,
+        imdbId: 'tt0083944',
+        images: [
+          {
+            coverType: 'poster',
+            url: '/movies/MediaCover/237/poster.jpg?lastWrite=636310780120000000'
+          },
+          {
+            coverType: 'banner',
+            url: '/movies/MediaCover/237/banner.jpg?lastWrite=636310780180000000'
+          }
+        ],
+        status: 'released',
+        quality: 'Any'
+      };
+
+      addArg = {
+        title: 'First Blood',
+        titleSlug: 'first-blood-1368',
+        tmdbId: 1368,
+        images: [
+          {
+            coverType: 'poster',
+            url: '/movies/MediaCover/237/poster.jpg?lastWrite=636310780120000000'
+          },
+          {
+            coverType: 'banner',
+            url: '/movies/MediaCover/237/banner.jpg?lastWrite=636310780180000000'
+          }
+        ],
+        qualityProfileId: 1,
+        rootFolderPath: '',
+        addOptions: {
+          searchForMovie: true
+        }
+      };
+
+      postStub = sandbox.stub(radarr.default(), 'post');
+    });
+
+    it('should return a correct response', async () => {
+      postStub.withArgs('movie', addArg).resolves(sampleMoviesResponse[2]);
+
+      const resp = await radarr.add(movie);
+      assert.deepEqual(resp, sampleMoviesResponse[2]);
+    });
+
+    it('should add using the quality from the config', async () => {
+      sandbox.stub(config, 'get').withArgs('alexa-libby.movies.quality').returns('HDTV-1080p');
+      const argWithQuality = merge(addArg, {qualityProfileId: 2});
+
+      await radarr.add(movie);
+      assert.equal(postStub.calledWith('movie', argWithQuality), true);
+    });
+  });
+});

--- a/test/api/sickbeard.js
+++ b/test/api/sickbeard.js
@@ -129,10 +129,6 @@ describe('api.sickbeard', () => {
       sbApiStub.withArgs('shows').resolves(sampleShowsResponse);
     });
 
-    afterEach(() => {
-      sandbox.reset();
-    });
-
     it('should list all the shows', async () => {
       const shows = await sickbeard.list();
       assert.equal(shows.length, 4);
@@ -166,10 +162,6 @@ describe('api.sickbeard', () => {
       sbApiStub.withArgs('sb.searchtvdb', {name: 'leno'}).resolves(sampleSearchTvdbResponse);
     });
 
-    afterEach(() => {
-      sandbox.reset();
-    });
-
     it('should return a formatted result', async () => {
       const shows = await sickbeard.search('leno');
 
@@ -196,10 +188,6 @@ describe('api.sickbeard', () => {
       };
 
       sbApiStub.withArgs('show.addnew', {tvdbid: 194751, status: 'wanted'}).resolves(sampleAddNew);
-    });
-
-    afterEach(() => {
-      sandbox.reset();
     });
 
     it('should add a show and return the response', async () => {

--- a/test/api/sickbeard.js
+++ b/test/api/sickbeard.js
@@ -112,12 +112,13 @@ describe('api.sickbeard', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    sbApiStub = sandbox.stub(sickbeard.default(), 'cmd');
 
     sandbox.stub(serverConfig, 'default').returns({
       url: 'http://localhost',
       apikey: 'abcdefghijklmnopqrstuvwxyz123456'
     });
+
+    sbApiStub = sandbox.stub(sickbeard.default(), 'cmd');
   });
 
   afterEach(() => {

--- a/test/api/sonarr.js
+++ b/test/api/sonarr.js
@@ -230,6 +230,11 @@ describe('api.sonarr', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    sandbox.stub(serverConfig, 'default').returns({
+      hostname: 'http://localhost',
+      apiKey: 'abcdefghijklmnopqrstuvwxyz123456'
+    });
+
     apiStub = sandbox.stub(sonarr.default(), 'get');
 
     apiStub.withArgs('rootfolder').resolves([{path: ''}]);
@@ -237,11 +242,6 @@ describe('api.sonarr', () => {
       {id: 1, name: 'Any'},
       {id: 2, name: 'HDTV-1080p'}
     ]);
-
-    sandbox.stub(serverConfig, 'default').returns({
-      hostname: 'http://localhost',
-      apiKey: 'abcdefghijklmnopqrstuvwxyz123456'
-    });
   });
 
   afterEach(() => {
@@ -398,7 +398,9 @@ describe('api.sonarr', () => {
     });
 
     it('should add using the quality from the config', async () => {
+      sandbox.stub(config, 'has').withArgs('alexa-libby.shows.quality').returns(true);
       sandbox.stub(config, 'get').withArgs('alexa-libby.shows.quality').returns('HDTV-1080p');
+
       const argWithQuality = merge(addArg, {qualityProfileId: 2});
 
       await sonarr.add(show);

--- a/test/api/sonarr.js
+++ b/test/api/sonarr.js
@@ -1,0 +1,408 @@
+import assert from 'assert';
+import config from 'config';
+import merge from 'deepmerge';
+import sinon from 'sinon';
+
+import * as serverConfig from '~/api/config.js';
+import * as sonarr from '~/api/sonarr.js';
+
+/* eslint-disable max-len */
+const sampleShowsResponse = [
+  {
+    title: 'Game of Thrones',
+    sortTitle: 'game thrones',
+    seasonCount: 7,
+    status: 'continuing',
+    overview: 'Seven noble families fight for control of the mythical land of Westeros. Friction between the houses leads to full-scale war. All while a very ancient evil awakens in the farthest north. Amidst the war, a neglected military order of misfits, the Night\'s Watch, is all that stands between the realms of men and the icy horrors beyond.',
+    network: 'HBO',
+    airTime: '21:00',
+    images: [
+      {
+        coverType: 'fanart',
+        url: 'http://thetvdb.com/banners/fanart/original/121361-94.jpg'
+      },
+      {
+        coverType: 'banner',
+        url: 'http://thetvdb.com/banners/graphical/121361-g19.jpg'
+      },
+      {
+        coverType: 'poster',
+        url: 'http://thetvdb.com/banners/posters/121361-59.jpg'
+      }
+    ],
+    remotePoster: 'http://thetvdb.com/banners/posters/121361-59.jpg',
+    seasons: [
+      {
+        seasonNumber: 0,
+        monitored: false
+      },
+      {
+        seasonNumber: 1,
+        monitored: true
+      },
+      {
+        seasonNumber: 2,
+        monitored: true
+      },
+      {
+        seasonNumber: 3,
+        monitored: true
+      },
+      {
+        seasonNumber: 4,
+        monitored: true
+      },
+      {
+        seasonNumber: 5,
+        monitored: true
+      },
+      {
+        seasonNumber: 6,
+        monitored: true
+      },
+      {
+        seasonNumber: 7,
+        monitored: true
+      }
+    ],
+    year: 2011,
+    profileId: 1,
+    seasonFolder: false,
+    monitored: true,
+    useSceneNumbering: false,
+    runtime: 55,
+    tvdbId: 121361,
+    tvRageId: 24493,
+    tvMazeId: 82,
+    firstAired: '2011-04-17T04:00:00Z',
+    seriesType: 'standard',
+    cleanTitle: 'gamethrones',
+    imdbId: 'tt0944947',
+    titleSlug: 'game-of-thrones',
+    certification: 'TV-MA',
+    genres: [
+      'Adventure',
+      'Drama',
+      'Fantasy'
+    ],
+    tags: [],
+    added: '0001-01-01T00:00:00Z',
+    ratings: {
+      votes: 1695,
+      value: 9.5
+    },
+    qualityProfileId: 1
+  },
+  {
+    title: 'Marvel\'s Jessica Jones',
+    sortTitle: 'marvels jessica jones',
+    seasonCount: 1,
+    status: 'continuing',
+    overview: 'A former superhero decides to reboot her life by becoming a private investigator.',
+    network: 'Netflix',
+    airTime: '00:01',
+    images: [
+      {
+        coverType: 'fanart',
+        url: 'http://thetvdb.com/banners/fanart/original/284190-17.jpg'
+      },
+      {
+        coverType: 'banner',
+        url: 'http://thetvdb.com/banners/graphical/284190-g6.jpg'
+      },
+      {
+        coverType: 'poster',
+        url: 'http://thetvdb.com/banners/posters/284190-9.jpg'
+      }
+    ],
+    remotePoster: 'http://thetvdb.com/banners/posters/284190-9.jpg',
+    seasons: [
+      {
+        seasonNumber: 1,
+        monitored: true
+      }
+    ],
+    year: 2015,
+    profileId: 1,
+    seasonFolder: false,
+    monitored: true,
+    useSceneNumbering: false,
+    runtime: 55,
+    tvdbId: 284190,
+    tvRageId: 0,
+    tvMazeId: 1370,
+    firstAired: '2015-11-20T05:00:00Z',
+    seriesType: 'standard',
+    cleanTitle: 'marvelsjessicajones',
+    imdbId: 'tt2357547',
+    titleSlug: 'marvels-jessica-jones',
+    certification: 'TV-MA',
+    genres: [
+      'Action',
+      'Crime',
+      'Drama',
+      'Suspense'
+    ],
+    tags: [],
+    added: '0001-01-01T00:00:00Z',
+    ratings: {
+      votes: 71,
+      value: 8.3
+    },
+    qualityProfileId: 1
+  },
+  {
+    title: 'Silicon Valley',
+    sortTitle: 'silicon valley',
+    seasonCount: 4,
+    status: 'continuing',
+    overview: 'In the high-tech gold rush of modern Silicon Valley, the people most qualified to succeed are the least capable of handling success. A comedy partially inspired by Mike Judge\'s own experiences as a Silicon Valley engineer in the late 1980s.',
+    network: 'HBO',
+    airTime: '22:00',
+    images: [
+      {
+        coverType: 'fanart',
+        url: 'http://thetvdb.com/banners/fanart/original/277165-5.jpg'
+      },
+      {
+        coverType: 'banner',
+        url: 'http://thetvdb.com/banners/graphical/277165-g9.jpg'
+      },
+      {
+        coverType: 'poster',
+        url: 'http://thetvdb.com/banners/posters/277165-8.jpg'
+      }
+    ],
+    remotePoster: 'http://thetvdb.com/banners/posters/277165-8.jpg',
+    seasons: [
+      {
+        seasonNumber: 0,
+        monitored: false
+      },
+      {
+        seasonNumber: 1,
+        monitored: true
+      },
+      {
+        seasonNumber: 2,
+        monitored: true
+      },
+      {
+        seasonNumber: 3,
+        monitored: true
+      },
+      {
+        seasonNumber: 4,
+        monitored: true
+      }
+    ],
+    year: 2014,
+    profileId: 2,
+    seasonFolder: false,
+    monitored: true,
+    useSceneNumbering: false,
+    runtime: 30,
+    tvdbId: 277165,
+    tvRageId: 33759,
+    tvMazeId: 143,
+    firstAired: '2014-04-06T04:00:00Z',
+    seriesType: 'standard',
+    cleanTitle: 'siliconvalley',
+    imdbId: 'tt2575988',
+    titleSlug: 'silicon-valley',
+    certification: 'TV-MA',
+    genres: [
+      'Comedy'
+    ],
+    tags: [],
+    added: '0001-01-01T00:00:00Z',
+    ratings: {
+      votes: 85,
+      value: 8.8
+    },
+    qualityProfileId: 2
+  }
+];
+/* eslint-enable max-len */
+
+describe('api.sonarr', () => {
+  let apiStub, sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    apiStub = sandbox.stub(sonarr.default(), 'get');
+
+    apiStub.withArgs('rootfolder').resolves([{path: ''}]);
+    apiStub.withArgs('profile').resolves([
+      {id: 1, name: 'Any'},
+      {id: 2, name: 'HDTV-1080p'}
+    ]);
+
+    sandbox.stub(serverConfig, 'default').returns({
+      hostname: 'http://localhost',
+      apiKey: 'abcdefghijklmnopqrstuvwxyz123456'
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('.list()', () => {
+    beforeEach(() => {
+      apiStub.withArgs('series').resolves(sampleShowsResponse);
+      apiStub.withArgs('series', {search: 'Silicon Valley'}).resolves([
+        sampleShowsResponse[2]
+      ]);
+    });
+
+    it('should list all the shows', async () => {
+      const shows = await sonarr.list();
+      assert.equal(shows.length, 3);
+    });
+
+    it('should list just shows with matching titles', async () => {
+      const shows = await sonarr.list('Jessica Jones');
+      assert.equal(shows.length, 1);
+    });
+
+    it('should format the show response to use standardized keys', async () => {
+      const shows = await sonarr.list();
+      assert.deepEqual(Object.keys(shows[0]),
+          ['title', 'slug', 'year', 'tvdbId', 'imdbId', 'images', 'status', 'quality']);
+    });
+
+    it('should fill in the correct data in the correct fields', async () => {
+      const [show] = await sonarr.list();
+
+      assert.deepEqual(show, {
+        title: 'Game of Thrones',
+        slug: 'game-of-thrones',
+        year: 2011,
+        tvdbId: 121361,
+        imdbId: 'tt0944947',
+        images: [
+          {
+            coverType: 'fanart',
+            url: 'http://thetvdb.com/banners/fanart/original/121361-94.jpg'
+          },
+          {
+            coverType: 'banner',
+            url: 'http://thetvdb.com/banners/graphical/121361-g19.jpg'
+          },
+          {
+            coverType: 'poster',
+            url: 'http://thetvdb.com/banners/posters/121361-59.jpg'
+          }
+        ],
+        status: 'continuing',
+        quality: 'Any'
+      });
+    });
+  });
+
+  describe('.search()', () => {
+    beforeEach(() => {
+      apiStub.withArgs('series/lookup', {term: 'jessica'}).resolves([
+        sampleShowsResponse[1]
+      ]);
+    });
+
+    it('should return a formatted result', async () => {
+      const [topResult] = await sonarr.search('jessica');
+
+      assert.deepEqual(topResult, {
+        title: 'Marvel\'s Jessica Jones',
+        slug: 'marvels-jessica-jones',
+        year: 2015,
+        tvdbId: 284190,
+        imdbId: 'tt2357547',
+        images: [
+          {
+            coverType: 'fanart',
+            url: 'http://thetvdb.com/banners/fanart/original/284190-17.jpg'
+          },
+          {
+            coverType: 'banner',
+            url: 'http://thetvdb.com/banners/graphical/284190-g6.jpg'
+          },
+          {
+            coverType: 'poster',
+            url: 'http://thetvdb.com/banners/posters/284190-9.jpg'
+          }
+        ],
+        status: 'continuing',
+        quality: 'Any'
+      });
+    });
+  });
+
+  describe('.add()', () => {
+    let show, addArg, postStub;
+
+    beforeEach(() => {
+      show = {
+        title: 'Silicon Valley',
+        slug: 'silicon-valley',
+        year: 2014,
+        tvdbId: 277165,
+        imdbId: 'tt2575988',
+        images: [
+          {
+            coverType: 'fanart',
+            url: 'http://thetvdb.com/banners/fanart/original/277165-5.jpg'
+          },
+          {
+            coverType: 'banner',
+            url: 'http://thetvdb.com/banners/graphical/277165-g9.jpg'
+          },
+          {
+            coverType: 'poster',
+            url: 'http://thetvdb.com/banners/posters/277165-8.jpg'
+          }
+        ],
+        status: 'continuing',
+        quality: 'HDTV-1080p'
+      };
+
+      addArg = {
+        title: 'Silicon Valley',
+        titleSlug: 'silicon-valley',
+        tvdbId: 277165,
+        images: [
+          {
+            coverType: 'fanart',
+            url: 'http://thetvdb.com/banners/fanart/original/277165-5.jpg'
+          },
+          {
+            coverType: 'banner',
+            url: 'http://thetvdb.com/banners/graphical/277165-g9.jpg'
+          },
+          {
+            coverType: 'poster',
+            url: 'http://thetvdb.com/banners/posters/277165-8.jpg'
+          }
+        ],
+        qualityProfileId: 1,
+        rootFolderPath: ''
+      };
+
+      postStub = sandbox.stub(sonarr.default(), 'post');
+    });
+
+    it('should return a correct response', async () => {
+      postStub.withArgs('series', addArg).resolves(sampleShowsResponse[2]);
+
+      const resp = await sonarr.add(show);
+      assert.deepEqual(resp, sampleShowsResponse[2]);
+    });
+
+    it('should add using the quality from the config', async () => {
+      sandbox.stub(config, 'get').withArgs('alexa-libby.shows.quality').returns('HDTV-1080p');
+      const argWithQuality = merge(addArg, {qualityProfileId: 2});
+
+      await sonarr.add(show);
+      assert.equal(postStub.calledWith('series', argWithQuality), true);
+    });
+  });
+});


### PR DESCRIPTION
You can now optionally supply a key called "quality" for each provider that matches the quality you want the media to download at. Note that the name of the quality has to match exactly what it's called in Sonarr or Radarr for it to work. Example:

```
  "server": {...}
  "movies": {
    "provider": "radarr",
    "server": {...},
    "quality": "HD-1080p"
  },
  "shows": {
    "provider": "sonarr",
    "server": {...},
    "quality": "HDTV-1080p"
  }
```

If you don't set a quality, it'll use whatever the first quality profile from the API is, usually "Any".

Closes #6 